### PR TITLE
Ignore deprecated BCD keys

### DIFF
--- a/src/sources/browser-compat-data.mts
+++ b/src/sources/browser-compat-data.mts
@@ -9,7 +9,9 @@ export function compatKeys(entryPoints: string[]) {
   const result = [];
   const compat = new Compat();
   for (const feature of compat.walk(entryPoints)) {
-    result.push(feature.id);
+    if (!feature.deprecated) {
+      result.push(feature.id);
+    }
   }
   return result;
 }


### PR DESCRIPTION
Untested.
Attempt to fix https://github.com/ddbeck/web-features-burndown-tools/issues/4